### PR TITLE
Fix Teamspeak typo on homepage

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -35,7 +35,7 @@
 			<div class="info well-g">
 				<h2>» Server Info «</h2>
 				<p>Server Address » <b>mc.overridenetwork.net</b></p>
-				<p>Temaspeak Address » <b>ts.overridenetwork.net</b></p>
+				<p>Teamspeak Address » <b>ts.overridenetwork.net</b></p>
 			</div>
 
 		<!-- END Server Info-->


### PR DESCRIPTION
Just realised that you accidently spelled Team Speak wrong. It was spelled Temaspeak but I fixed it to Teamspeak. Anyways you are welcome.